### PR TITLE
[BE-13] Create method to retrieve transactions on blockchain

### DIFF
--- a/app/Infrastructure/ExternalData/ArkClientApi.php
+++ b/app/Infrastructure/ExternalData/ArkClientApi.php
@@ -20,4 +20,10 @@ class ArkClientApi
         $response = $this->httpClient->get($action);
         return json_decode($response->getBody(), true);
     }
+
+    function listTransactions(string $action): array
+    {
+        $response = $this->httpClient->get($action);
+        return json_decode($response->getBody(), true);
+    }
 }

--- a/tests/Infrastructure/ExternalData/ArkClientApiTest.php
+++ b/tests/Infrastructure/ExternalData/ArkClientApiTest.php
@@ -27,4 +27,19 @@ class ArkClientApiTest extends TestCase
 
         $this->assertEquals(json_decode($expected, true), $response);
     }
+
+    public function test_it_should_list_blockchain_transactions(){
+        $expected = ListBlocksMock::jsonResponse();
+        $action = 'transactions';
+        $httpClient = Mockery::mock(Client::class);
+        $arkClientApi = new ArkClientApi($httpClient);
+        $responseHttpClient = $this->createMock(Response::class);
+
+        $httpClient->shouldReceive('get')->with($action)->andReturn($responseHttpClient);
+        $responseHttpClient->expects($this->once())->method('getBody')->willReturn($expected);
+
+        $response = $arkClientApi->listBlocks('transactions');
+
+        $this->assertEquals(json_decode($expected, true), $response);
+    }
 }


### PR DESCRIPTION
## Why? 🤔 

This PR is responsible to create the method on `ArkClientApi` to retrieve transactions.

## What changed? 🏗️ 

- Class `ArkClientApi`: Add method `listTransactions`.

## Jira 🧩 
Epic https://blockchain-explorer.atlassian.net/browse/BE-1
Story https://blockchain-explorer.atlassian.net/browse/BE-3

## Feature branch 🚀 
`feature/list-transactions`
