### PR TITLE
[BE-14] Add method list transactions handler on infra service

### DIFF
--- a/app/Infrastructure/ExternalData/ArkClientService.php
+++ b/app/Infrastructure/ExternalData/ArkClientService.php
@@ -6,6 +6,7 @@ namespace App\Infrastructure\ExternalData;
 
 use App\Infrastructure\ExternalData\Exceptions\ArkClientApiException;
 use App\Infrastructure\ExternalData\Requests\ListBlocksRequest;
+use App\Infrastructure\ExternalData\Requests\ListTransactionsRequest;
 use GuzzleHttp\Exception\TransferException;
 
 class ArkClientService
@@ -22,6 +23,16 @@ class ArkClientService
         try {
             $action = $request::getHttpAction();
             return $this->arkClientApi->listBlocks($action);
+        } catch (TransferException $exception) {
+            throw new ArkClientApiException($exception->getMessage());
+        }
+    }
+
+    function handleListTransactions(ListTransactionsRequest $request): array
+    {
+        try {
+            $action = $request::getHttpAction();
+            return $this->arkClientApi->listTransactions($action);
         } catch (TransferException $exception) {
             throw new ArkClientApiException($exception->getMessage());
         }

--- a/app/Infrastructure/ExternalData/Exceptions/ArkClientApiException.php
+++ b/app/Infrastructure/ExternalData/Exceptions/ArkClientApiException.php
@@ -4,12 +4,9 @@
 namespace App\Infrastructure\ExternalData\Exceptions;
 
 
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use GuzzleHttp\Exception\TransferException;
 
-class ArkClientApiException extends HttpException
+class ArkClientApiException extends TransferException
 {
-    public function __construct(string $message, int $statusCode)
-    {
-        parent::__construct($statusCode, $message);
-    }
+
 }

--- a/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
+++ b/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace App\Infrastructure\ExternalData\Requests;
+
+
+class ListBlocksRequest
+{
+    const ACTION_URI = 'blocks';
+
+    public static function getHttpAction(): string {
+        return self::ACTION_URI;
+    }
+}

--- a/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
+++ b/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
@@ -4,9 +4,9 @@
 namespace App\Infrastructure\ExternalData\Requests;
 
 
-class ListBlocksRequest
+class ListTransactionsRequest
 {
-    const ACTION_URI = 'blocks';
+    const ACTION_URI = 'transactions';
 
     public static function getHttpAction(): string {
         return self::ACTION_URI;

--- a/tests/Infrastructure/ExternalData/ArkClientServiceTest.php
+++ b/tests/Infrastructure/ExternalData/ArkClientServiceTest.php
@@ -8,6 +8,7 @@ use App\Infrastructure\ExternalData\ArkClientApi;
 use App\Infrastructure\ExternalData\ArkClientService;
 use App\Infrastructure\ExternalData\Exceptions\ArkClientApiException;
 use App\Infrastructure\ExternalData\Requests\ListBlocksRequest;
+use App\Infrastructure\ExternalData\Requests\ListTransactionsRequest;
 use GuzzleHttp\Exception\TransferException;
 use Tests\TestCase;
 
@@ -39,5 +40,33 @@ class ArkClientServiceTest extends TestCase
         $this->expectExceptionMessage('error');
 
         $arkClientService->handleListBlocks($request);
+    }
+
+    public function test_it_should_handle_list_transactions_request(){
+        $arkClientApi = $this->createMock(ArkClientApi::class);
+        $arkClientService = new ArkClientService($arkClientApi);
+        $request = new ListTransactionsRequest();
+        $expected = ["fake-response"];
+
+        $arkClientApi->expects($this->once())->method('listTransactions')->with($request::getHttpAction())
+            ->willReturn($expected);
+
+        $response = $arkClientService->handleListTransactions($request);
+
+        $this->assertEquals($expected, $response);
+    }
+
+    public function test_it_throws_transactions_when_there_is_an_error(){
+        $arkClientApi = $this->createMock(ArkClientApi::class);
+        $arkClientService = new ArkClientService($arkClientApi);
+        $request = new ListTransactionsRequest();
+
+        $arkClientApi->expects($this->once())->method('listTransactions')->with($request::getHttpAction())
+            ->willThrowException(new TransferException('error'));
+
+        $this->expectException(ArkClientApiException::class);
+        $this->expectExceptionMessage('error');
+
+        $arkClientService->handleListTransactions($request);
     }
 }


### PR DESCRIPTION
## Why? 🤔 

This PR is responsible to create the method handler on `ArkClientService` to retrieve transactions.

## What changed? 🏗️ 

- Class `ArkClientService`: Add method `handleListTransactions `.
- Create `ListTransactionsRequest`: Contain the properties to the ark api request,
- Refact on `ArkClientApiException`.

## Jira 🧩 
Epic https://blockchain-explorer.atlassian.net/browse/BE-1
Story https://blockchain-explorer.atlassian.net/browse/BE-3

## Feature branch 🚀 
`feature/list-transactions`
