### PR TITLE
[BE-5] Create transaction factory

### DIFF
--- a/app/Domain/Explorer/Factories/CollectionsTransactionFactory.php
+++ b/app/Domain/Explorer/Factories/CollectionsTransactionFactory.php
@@ -5,10 +5,8 @@ namespace App\Domain\Explorer\Factories;
 
 
 use App\Domain\Explorer\Models\CollectionsTransactionDTO;
-use App\Domain\Explorer\Models\TimestampDTO;
-use App\Domain\Explorer\Models\TransactionDTO;
 
-class CollectionsTransactionFactory
+class CollectionsTransactionFactory extends TransactionFactory
 {
     public function buildCollection(array $response): CollectionsTransactionDTO {
         $collectionTransactions = new CollectionsTransactionDTO();
@@ -32,34 +30,5 @@ class CollectionsTransactionFactory
             ->setTransactions($transactionsList);
 
         return $collectionTransactions;
-    }
-
-    private function createTransaction(array $response): TransactionDTO {
-        $transaction = new TransactionDTO();
-
-        return $transaction
-            ->setId($response['id'])
-            ->setBlockId($response['blockId'])
-            ->setVersion($response['version'])
-            ->setType($response['type'])
-            ->setTypeGroup($response['typeGroup'])
-            ->setAmount($response['amount'])
-            ->setFee($response['fee'])
-            ->setSender($response['sender'])
-            ->setSenderPublicKey($response['senderPublicKey'])
-            ->setRecipient($response['recipient'])
-            ->setSignature($response['signature'])
-            ->setConfirmations($response['confirmations'])
-            ->setTimestamp($this->createTimestamp($response['timestamp']))
-            ->setNonce($response['nonce']);
-    }
-
-    private function createTimestamp(array $response): TimestampDTO {
-        $timestamp = new TimestampDTO();
-
-        return $timestamp
-            ->setEpoch($response['epoch'])
-            ->setUnix($response['unix'])
-            ->setHuman($response['human']);
     }
 }

--- a/app/Domain/Explorer/Factories/TransactionFactory.php
+++ b/app/Domain/Explorer/Factories/TransactionFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace App\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Models\TimestampDTO;
+use App\Domain\Explorer\Models\TransactionDTO;
+
+class TransactionFactory
+{
+    public function createTransaction(array $response): TransactionDTO {
+        $transaction = new TransactionDTO();
+
+        return $transaction
+            ->setId($response['id'])
+            ->setBlockId($response['blockId'])
+            ->setVersion($response['version'])
+            ->setType($response['type'])
+            ->setTypeGroup($response['typeGroup'])
+            ->setAmount($response['amount'])
+            ->setFee($response['fee'])
+            ->setSender($response['sender'])
+            ->setSenderPublicKey($response['senderPublicKey'])
+            ->setRecipient($response['recipient'])
+            ->setSignature($response['signature'])
+            ->setConfirmations($response['confirmations'])
+            ->setTimestamp($this->createTimestamp($response['timestamp']))
+            ->setNonce($response['nonce']);
+    }
+
+    private function createTimestamp(array $response): TimestampDTO {
+        $timestamp = new TimestampDTO();
+
+        return $timestamp
+            ->setEpoch($response['epoch'])
+            ->setUnix($response['unix'])
+            ->setHuman($response['human']);
+    }
+}

--- a/app/Domain/Explorer/Services/RetrieveTransactionsService.php
+++ b/app/Domain/Explorer/Services/RetrieveTransactionsService.php
@@ -16,19 +16,22 @@ class RetrieveTransactionsService
     /** @var CollectionsTransactionFactory */
     private $transactionsFactory;
 
-    /** @var ListTransactionsRequest */
-    private $request;
-
-    function __construct(ArkClientService $arkClientService, CollectionsTransactionFactory $transactionsFactory,
-                         ListTransactionsRequest $request) {
+    function __construct(ArkClientService $arkClientService, CollectionsTransactionFactory $transactionsFactory) {
         $this->arkClientService = $arkClientService;
         $this->transactionsFactory = $transactionsFactory;
-        $this->request = $request;
     }
 
-    public function execute(){
-        $transactionsPayload = $this->arkClientService->handleRequest($this->request);
+    public function execute(ListTransactionsRequest $request) {
+        $transactionsPayload = $this->arkClientService->handleRequest($request);
 
-        return $this->transactionsFactory->buildCollection($transactionsPayload);
+        if ($this->isCollection($transactionsPayload)) {
+            return $this->transactionsFactory->buildCollection($transactionsPayload);
+        } else {
+            return $this->transactionsFactory->createTransaction($transactionsPayload['data']);
+        }
+    }
+
+    private function isCollection(array $transactionsPayload): bool {
+        return (count($transactionsPayload) > 1) ? true : false;
     }
 }

--- a/app/Infrastructure/ExternalData/ArkClientService.php
+++ b/app/Infrastructure/ExternalData/ArkClientService.php
@@ -22,7 +22,7 @@ class ArkClientService
     function handleRequest(IOperationRequest $request): array
     {
         try {
-            $action = $request::getHttpAction();
+            $action = $request->getHttpAction();
             return $this->arkClientApi->request($action);
         } catch (TransferException $exception) {
             throw new ArkClientApiException($exception->getMessage());

--- a/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
+++ b/app/Infrastructure/ExternalData/Requests/ListTransactionsRequest.php
@@ -6,9 +6,13 @@ namespace App\Infrastructure\ExternalData\Requests;
 
 class ListTransactionsRequest implements IOperationRequest
 {
-    const ACTION_URI = 'transactions';
+    private $action_uri = 'transactions';
 
-    public static function getHttpAction(): string {
-        return self::ACTION_URI;
+    public function getHttpAction(): string {
+        return $this->action_uri;
+    }
+
+    public function withId(string $id) {
+        $this->action_uri = $this->action_uri . '/' . $id;
     }
 }

--- a/tests/Domain/Explorer/Factories/CollectionTransactionsFactoryTest.php
+++ b/tests/Domain/Explorer/Factories/CollectionTransactionsFactoryTest.php
@@ -4,11 +4,8 @@
 namespace Tests\Domain\Explorer\Factories;
 
 
-use App\Domain\Explorer\Factories\CollectionBlocksFactory;
 use App\Domain\Explorer\Factories\CollectionsTransactionFactory;
-use Tests\Support\Builders\CollectionBlocksSupportBuilder;
 use Tests\Support\Builders\CollectionTransactionSupportBuilder;
-use Tests\Support\ListBlocksMock;
 use Tests\Support\ListTransactionsMock;
 use Tests\TestCase;
 

--- a/tests/Domain/Explorer/Factories/TransactionFactoryTest.php
+++ b/tests/Domain/Explorer/Factories/TransactionFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Tests\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Factories\CollectionBlocksFactory;
+use App\Domain\Explorer\Factories\CollectionsTransactionFactory;
+use App\Domain\Explorer\Factories\TransactionFactory;
+use Tests\Support\Builders\CollectionBlocksSupportBuilder;
+use Tests\Support\Builders\CollectionTransactionSupportBuilder;
+use Tests\Support\ListBlocksMock;
+use Tests\Support\ListTransactionsMock;
+use Tests\TestCase;
+
+class TransactionFactoryTest extends TestCase
+{
+    public function test_it_creates_transaction(){
+        $factory = new TransactionFactory();
+        $transactionPayload = json_decode(ListTransactionsMock::jsonResponse(), true);
+        $expected = CollectionTransactionSupportBuilder::createTransaction();
+
+        $response = $factory->createTransaction($transactionPayload['data'][0]);
+
+        $this->assertEquals($expected, $response);
+    }
+}

--- a/tests/Domain/Explorer/Services/RetrieveTransactionsServiceTest.php
+++ b/tests/Domain/Explorer/Services/RetrieveTransactionsServiceTest.php
@@ -6,6 +6,7 @@ namespace Tests\Domain\Explorer\Services;
 
 use App\Domain\Explorer\Factories\CollectionsTransactionFactory;
 use App\Domain\Explorer\Models\CollectionsTransactionDTO;
+use App\Domain\Explorer\Models\TransactionDTO;
 use App\Domain\Explorer\Services\RetrieveTransactionsService;
 use App\Infrastructure\ExternalData\ArkClientService;
 use App\Infrastructure\ExternalData\Requests\ListTransactionsRequest;
@@ -17,17 +18,35 @@ class RetrieveTransactionsServiceTest extends TestCase
         $arkClientService = $this->createMock(ArkClientService::class);
         $transactionFactory = $this->createMock(CollectionsTransactionFactory::class);
         $request = new ListTransactionsRequest();
-        $transactionPayload = ["fake-payload-response"];
-        $collectionBlocks = $this->createMock(CollectionsTransactionDTO::class);
-        $service = new RetrieveTransactionsService($arkClientService, $transactionFactory, $request);
+        $transactionPayload = ["fake-payload-response", "fake-payload-response"];
+        $collectionTransactions = $this->createMock(CollectionsTransactionDTO::class);
+        $service = new RetrieveTransactionsService($arkClientService, $transactionFactory);
 
         $arkClientService->expects($this->once())->method('handleRequest')->with($request)
             ->willReturn($transactionPayload);
         $transactionFactory->expects($this->once())->method('buildCollection')->with($transactionPayload)
-            ->willReturn($collectionBlocks);
+            ->willReturn($collectionTransactions);
 
-        $response = $service->execute();
+        $response = $service->execute($request);
 
-        $this->assertEquals($collectionBlocks, $response);
+        $this->assertEquals($collectionTransactions, $response);
+    }
+
+    public function test_it_returns_transaction(){
+        $arkClientService = $this->createMock(ArkClientService::class);
+        $transactionFactory = $this->createMock(CollectionsTransactionFactory::class);
+        $request = new ListTransactionsRequest();
+        $transactionPayload = [ "data" => ["fake-payload-response"]];
+        $transaction = $this->createMock(TransactionDTO::class);
+        $service = new RetrieveTransactionsService($arkClientService, $transactionFactory);
+
+        $arkClientService->expects($this->once())->method('handleRequest')->with($request)
+            ->willReturn($transactionPayload);
+        $transactionFactory->expects($this->once())->method('createTransaction')->with($transactionPayload['data'])
+            ->willReturn($transaction);
+
+        $response = $service->execute($request);
+
+        $this->assertEquals($transaction, $response);
     }
 }

--- a/tests/Infrastructure/ExternalData/ArkClientServiceTest.php
+++ b/tests/Infrastructure/ExternalData/ArkClientServiceTest.php
@@ -39,7 +39,7 @@ class ArkClientServiceTest extends TestCase
         $action = "fake-action";
 
         $request->shouldReceive('getHttpAction')->andReturn($action);
-        $arkClientApi->expects($this->once())->method('request')->with($request::getHttpAction())
+        $arkClientApi->expects($this->once())->method('request')->with($action)
             ->willThrowException(new TransferException('fake-error'));
 
         $this->expectException(ArkClientApiException::class);

--- a/tests/Infrastructure/Request/ListBlockRequestTest.php
+++ b/tests/Infrastructure/Request/ListBlockRequestTest.php
@@ -12,6 +12,6 @@ class ListBlockRequestTest extends TestCase
     public function test_it_returns_action_list_blocks_uri(){
         $request = new ListBlocksRequest();
 
-        $this->assertEquals('blocks', $request::ACTION_URI);
+        $this->assertEquals('blocks', $request->getHttpAction());
     }
 }

--- a/tests/Support/Builders/CollectionTransactionSupportBuilder.php
+++ b/tests/Support/Builders/CollectionTransactionSupportBuilder.php
@@ -27,7 +27,7 @@ class CollectionTransactionSupportBuilder
             ->setTransactions(collect([self::createTransaction(), self::createTransaction()]));
     }
 
-    private static function createTransaction(): TransactionDTO {
+    public static function createTransaction(): TransactionDTO {
         $transaction = new TransactionDTO();
 
         return $transaction


### PR DESCRIPTION
## Why? 🤔 

This PR is responsible to create single transaction through factory.

## What changed? 🏗️ 

- Create `TransactionFactory`:  Executed an extraction method from `CollectionTransactionsFactory` to get the responsibility to create a transaction and put in `TransactionFactory` class. The `CollectionTransactionsFactory` extends this behaviour.
- Refact`RetrieveTransactionsService`: Checks when will build a collection of transactions or a single transaction.
- Refact `Request` Classes: Change  function visibility and add action to search by id.

## Jira 🧩 
Epic https://blockchain-explorer.atlassian.net/browse/BE-1
Story https://blockchain-explorer.atlassian.net/browse/BE-5

## Feature branch 🚀 
`feature/show-transaction-details`
