### PR TITLE
[BE-21] Create wallets collection domain service and factory 

### DIFF
--- a/app/Domain/Explorer/Factories/WalletsCollectionFactory.php
+++ b/app/Domain/Explorer/Factories/WalletsCollectionFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace App\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Models\CollectionsWalletDTO;
+use App\Domain\Explorer\Models\WalletDTO;
+
+class WalletsCollectionFactory
+{
+    public function buildCollection(array $payload): CollectionsWalletDTO {
+        $walletsCollection = new CollectionsWalletDTO();
+        $walletsList = collect();
+
+        foreach ($payload['data'] as $walletPayload){
+            $wallet = $this->createWallet($walletPayload);
+            $walletsList->push($wallet);
+        }
+
+        $walletsCollection
+            ->setCount($payload['meta']['count'])
+            ->setPageCount($payload['meta']['pageCount'])
+            ->setTotalCount($payload['meta']['totalCount'])
+            ->setNext($payload['meta']['next'])
+            ->setPrevious(!empty($payload['meta']['previous']) ?: "")
+            ->setSelf($payload['meta']['self'])
+            ->setFirst($payload['meta']['first'])
+            ->setLast($payload['meta']['last'])
+            ->setWallet($walletsList);
+
+        return $walletsCollection;
+    }
+
+    private function createWallet(array $walletPayload): WalletDTO{
+        $wallet = new WalletDTO();
+
+        return $wallet
+            ->setAddress($walletPayload['address'])
+            ->setPublicKey($walletPayload['publicKey'])
+            ->setNonce($walletPayload['nonce'])
+            ->setBalance($walletPayload['balance'])
+            ->setIsDelegate($walletPayload['isDelegate'])
+            ->setIsResigned($walletPayload['isResigned']);
+    }
+}

--- a/app/Domain/Explorer/Factories/WalletsCollectionFactory.php
+++ b/app/Domain/Explorer/Factories/WalletsCollectionFactory.php
@@ -37,7 +37,7 @@ class WalletsCollectionFactory
 
         return $wallet
             ->setAddress($walletPayload['address'])
-            ->setPublicKey($walletPayload['publicKey'])
+            ->setPublicKey(!empty($walletPayload['publicKey']) ?: "")
             ->setNonce($walletPayload['nonce'])
             ->setBalance($walletPayload['balance'])
             ->setIsDelegate($walletPayload['isDelegate'])

--- a/app/Domain/Explorer/Services/RetrieveWalletsService.php
+++ b/app/Domain/Explorer/Services/RetrieveWalletsService.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace App\Domain\Explorer\Services;
+
+
+use App\Domain\Explorer\Factories\WalletsCollectionFactory;
+use App\Infrastructure\ExternalData\ArkClientService;
+use App\Infrastructure\ExternalData\Requests\WalletsRequest;
+
+class RetrieveWalletsService
+{
+    /** @var ArkClientService */
+    private $arkClientService;
+
+    /** @var WalletsCollectionFactory */
+    private $walletsFactory;
+
+    function __construct(ArkClientService $arkClientService, WalletsCollectionFactory $walletsFactory)
+    {
+        $this->arkClientService = $arkClientService;
+        $this->walletsFactory = $walletsFactory;
+    }
+
+    public function execute(WalletsRequest $request)
+    {
+        $walletsPayload = $this->arkClientService->handleRequest($request);
+
+        return $this->walletsFactory->buildCollection($walletsPayload);
+    }
+}

--- a/app/Infrastructure/ExternalData/Requests/WalletsRequest.php
+++ b/app/Infrastructure/ExternalData/Requests/WalletsRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace App\Infrastructure\ExternalData\Requests;
+
+
+class WalletsRequest implements IOperationRequest
+{
+    private $action_uri = 'wallets';
+
+    public function getHttpAction(): string {
+        return $this->action_uri;
+    }
+}

--- a/tests/Domain/Explorer/Factories/WalletsCollectionFactoryTest.php
+++ b/tests/Domain/Explorer/Factories/WalletsCollectionFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Tests\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Factories\WalletsCollectionFactory;
+use Tests\Support\Builders\CollectionWalletsSupportBuilder;
+use Tests\Support\WalletsListMock;
+use Tests\TestCase;
+
+class WalletsCollectionFactoryTest extends TestCase
+{
+    public function test_it_creates_wallets_collection(){
+        $factory = new WalletsCollectionFactory();
+        $walletsPayload = json_decode(WalletsListMock::jsonResponse(), true);
+        $expected = CollectionWalletsSupportBuilder::buildDefault();
+
+        $response = $factory->buildCollection($walletsPayload);
+
+        $this->assertEquals($expected, $response);
+    }
+}

--- a/tests/Domain/Explorer/Services/RetrieveWalletsServiceTest.php
+++ b/tests/Domain/Explorer/Services/RetrieveWalletsServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Tests\Domain\Explorer\Services;
+
+
+use App\Domain\Explorer\Factories\WalletsCollectionFactory;
+use App\Domain\Explorer\Models\CollectionsWalletDTO;
+use App\Domain\Explorer\Services\RetrieveWalletsService;
+use App\Infrastructure\ExternalData\ArkClientService;
+use App\Infrastructure\ExternalData\Requests\WalletsRequest;
+use Tests\TestCase;
+
+class RetrieveWalletsServiceTest extends TestCase
+{
+    public function test_it_returns_wallets_list(){
+        $arkClientService = $this->createMock(ArkClientService::class);
+        $walletsFactory = $this->createMock(WalletsCollectionFactory::class);
+        $request = new WalletsRequest();
+        $walletsPayload = ["fake-payload-response", "fake-payload-response"];
+        $walletCollections = $this->createMock(CollectionsWalletDTO::class);
+        $service = new RetrieveWalletsService($arkClientService, $walletsFactory);
+
+        $arkClientService->expects($this->once())->method('handleRequest')->with($request)
+            ->willReturn($walletsPayload);
+        $walletsFactory->expects($this->once())->method('buildCollection')->with($walletsPayload)
+            ->willReturn($walletCollections);
+
+        $response = $service->execute($request);
+
+        $this->assertEquals($walletCollections, $response);
+    }
+}

--- a/tests/Support/Builders/CollectionWalletsSupportBuilder.php
+++ b/tests/Support/Builders/CollectionWalletsSupportBuilder.php
@@ -17,23 +17,25 @@ class CollectionWalletsSupportBuilder
         $collections = new CollectionsWalletDTO();
 
         return $collections
+            ->setCount(100)
+            ->setPageCount(40366)
             ->setTotalCount(4036503)
             ->setNext("/transactions?transform=true&page=2&limit=100")
             ->setPrevious("")
             ->setSelf("/transactions?transform=true&page=1&limit=100")
             ->setFirst("/transactions?transform=true&page=1&limit=100")
             ->setLast("/transactions?transform=true&page=40366&limit=100")
-            ->setWallet(collect([self::createWallet(), self::createTransaction()]));
+            ->setWallet(collect([self::createWallet(), self::createWallet()]));
     }
 
     public static function createWallet(): WalletDTO {
         $wallet = new WalletDTO();
 
         return $wallet
-            ->setAddress('AdS7WvzqusoP759qRo6HDmUz2L34u4fMHz')
-            ->setPublicKey('03e7635481b035149829ef74f972e69eca75363bc96e75be57579b0e6fb3f22192')
-            ->setNonce('20')
-            ->setBalance('698316659123862')
+            ->setAddress('AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK')
+            ->setPublicKey('02ff171adaef486b7db9fc160b28433d20cf43163d56fd28fee72145f0d5219a4b')
+            ->setNonce('123102')
+            ->setBalance('691647933769922')
             ->setIsDelegate(false)
             ->setIsResigned(false);
     }

--- a/tests/Support/WalletsListMock.php
+++ b/tests/Support/WalletsListMock.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Tests\Support;
+
+
+class WalletsListMock
+{
+    public static function jsonResponse()
+    {
+        return json_encode([
+            "meta" => [
+                "count" => 100,
+                "pageCount" => 40366,
+                "totalCount" => 4036503,
+                "next" => "/transactions?transform=true&page=2&limit=100",
+                "previous" => null,
+                "self" => "/transactions?transform=true&page=1&limit=100",
+                "first" => "/transactions?transform=true&page=1&limit=100",
+                "last" => "/transactions?transform=true&page=40366&limit=100"
+            ],
+            "data" => [[
+                "address" => "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK",
+                "publicKey" => "02ff171adaef486b7db9fc160b28433d20cf43163d56fd28fee72145f0d5219a4b",
+                "nonce" => "123102",
+                "balance" => "691647933769922",
+                "isDelegate" => false,
+                "isResigned" => false
+            ], [
+                "address" => "AUexKjGtgsSpVzPLs6jNMM6vJ6znEVTQWK",
+                "publicKey" => "02ff171adaef486b7db9fc160b28433d20cf43163d56fd28fee72145f0d5219a4b",
+                "nonce" => "123102",
+                "balance" => "691647933769922",
+                "isDelegate" => false,
+                "isResigned" => false
+            ]]
+        ]);
+    }
+}


### PR DESCRIPTION
## Why? 🤔 

This PR is responsible to create the domain service and factory for wallets collection.

## What changed? 🏗️ 

- Create `WalletsCollectionFactory`: To build the Wallets Collection Model.
- Create `RetrieveWalletsService`: To orchestrate the request and creation of the collection wallets.
- Create `CollectionWalletsSupportBuilder` and `WalletsListMock`: To help on unit testing.
- Create `WalletsRequest`: The request structure to the ark api.


## Jira 🧩 
Epic https://blockchain-explorer.atlassian.net/browse/BE-1
Story https://blockchain-explorer.atlassian.net/browse/BE-6

## Feature branch 🚀 
`feature/list-wallets`
