### PR TITLE
[BE-24] Create domain service and factory

### DIFF
--- a/app/Domain/Explorer/Factories/DelegatesCollectionFactory.php
+++ b/app/Domain/Explorer/Factories/DelegatesCollectionFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace App\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Models\DelegateDTO;
+use App\Domain\Explorer\Models\DelegatesCollectionDTO;
+
+class DelegatesCollectionFactory
+{
+    public function buildCollection(array $payload): DelegatesCollectionDTO {
+        $delegatesCollection = new DelegatesCollectionDTO();
+        $delegatesList = collect();
+
+        foreach ($payload['data'] as $delegatesPayload){
+            $wallet = $this->createDelegate($delegatesPayload);
+            $delegatesList->push($wallet);
+        }
+
+        $delegatesCollection
+            ->setCount($payload['meta']['count'])
+            ->setPageCount($payload['meta']['pageCount'])
+            ->setTotalCount($payload['meta']['totalCount'])
+            ->setNext($payload['meta']['next'])
+            ->setPrevious(!empty($payload['meta']['previous']) ?: "")
+            ->setSelf($payload['meta']['self'])
+            ->setFirst($payload['meta']['first'])
+            ->setLast($payload['meta']['last'])
+            ->setDelegates($delegatesList);
+
+        return $delegatesCollection;
+    }
+
+    private function createDelegate(array $walletPayload): DelegateDTO {
+        $delegate = new DelegateDTO();
+
+        return $delegate
+            ->setUsername($walletPayload['username'])
+            ->setAddress($walletPayload['address'])
+            ->setPublicKey($walletPayload['publicKey'])
+            ->setVotes($walletPayload['votes'])
+            ->setRank($walletPayload['rank'])
+            ->setIsResigned($walletPayload['isResigned']);
+    }
+}

--- a/app/Domain/Explorer/Services/RetrieveDelegatesService.php
+++ b/app/Domain/Explorer/Services/RetrieveDelegatesService.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace App\Domain\Explorer\Services;
+
+
+use App\Domain\Explorer\Factories\DelegatesCollectionFactory;
+use App\Infrastructure\ExternalData\ArkClientService;
+use App\Infrastructure\ExternalData\Requests\DelegatesRequest;
+
+class RetrieveDelegatesService
+{
+    /** @var ArkClientService */
+    private $arkClientService;
+
+    /** @var DelegatesCollectionFactory */
+    private $delegatesFactory;
+
+    function __construct(ArkClientService $arkClientService, DelegatesCollectionFactory $delegatesFactory)
+    {
+        $this->arkClientService = $arkClientService;
+        $this->delegatesFactory = $delegatesFactory;
+    }
+
+    public function execute(DelegatesRequest $request)
+    {
+        $delegatesPayload = $this->arkClientService->handleRequest($request);
+
+        return $this->delegatesFactory->buildCollection($delegatesPayload);
+    }
+}

--- a/app/Infrastructure/ExternalData/Requests/DelegatesRequest.php
+++ b/app/Infrastructure/ExternalData/Requests/DelegatesRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace App\Infrastructure\ExternalData\Requests;
+
+
+class DelegatesRequest implements IOperationRequest
+{
+    private $action_uri = 'delegates';
+
+    public function getHttpAction(): string {
+        return $this->action_uri;
+    }
+}

--- a/tests/Domain/Explorer/Factories/DelegatesCollectionFactoryTest.php
+++ b/tests/Domain/Explorer/Factories/DelegatesCollectionFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Tests\Domain\Explorer\Factories;
+
+
+use App\Domain\Explorer\Factories\DelegatesCollectionFactory;
+use Tests\Support\Builders\CollectionDelegatesSupportBuilder;
+use Tests\Support\DelegatesListMock;
+use Tests\TestCase;
+
+class DelegatesCollectionFactoryTest extends TestCase
+{
+    public function test_it_creates_delegates_collection(){
+        $factory = new DelegatesCollectionFactory();
+        $delegatesPayload = json_decode(DelegatesListMock::jsonResponse(), true);
+        $expected = CollectionDelegatesSupportBuilder::buildDefault();
+
+        $response = $factory->buildCollection($delegatesPayload);
+
+        $this->assertEquals($expected, $response);
+    }
+}

--- a/tests/Domain/Explorer/Services/RetrieveDelegatesServiceTest.php
+++ b/tests/Domain/Explorer/Services/RetrieveDelegatesServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace Tests\Domain\Explorer\Services;
+
+
+use App\Domain\Explorer\Factories\DelegatesCollectionFactory;
+use App\Domain\Explorer\Models\DelegatesCollectionDTO;
+use App\Domain\Explorer\Services\RetrieveDelegatesService;
+use App\Infrastructure\ExternalData\ArkClientService;
+use App\Infrastructure\ExternalData\Requests\DelegatesRequest;
+use Tests\TestCase;
+
+class RetrieveDelegatesServiceTest extends TestCase
+{
+    public function test_it_returns_delegates_list(){
+        $arkClientService = $this->createMock(ArkClientService::class);
+        $delegatesFactory = $this->createMock(DelegatesCollectionFactory::class);
+        $request = new DelegatesRequest();
+        $delegatesPayload = ["fake-payload-response", "fake-payload-response"];
+        $delegatesCollection = $this->createMock(DelegatesCollectionDTO::class);
+        $service = new RetrieveDelegatesService($arkClientService, $delegatesFactory);
+
+        $arkClientService->expects($this->once())->method('handleRequest')->with($request)
+            ->willReturn($delegatesPayload);
+        $delegatesFactory->expects($this->once())->method('buildCollection')->with($delegatesPayload)
+            ->willReturn($delegatesCollection);
+
+        $response = $service->execute($request);
+
+        $this->assertEquals($delegatesCollection, $response);
+    }
+}

--- a/tests/Support/DelegatesListMock.php
+++ b/tests/Support/DelegatesListMock.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Tests\Support;
+
+
+class DelegatesListMock
+{
+    public static function jsonResponse()
+    {
+        return json_encode([
+            "meta" => [
+                "count" => 100,
+                "pageCount" => 12,
+                "totalCount" => 1132,
+                "next" => "/delegates?page=2&limit=100",
+                "previous" => null,
+                "self" => "/delegates?page=1&limit=100",
+                "first" => "/delegates?page=1&limit=100",
+                "last" => "/delegates?page=12&limit=100"
+            ],
+            "data" => [[
+                "username" => "biz_classic",
+                "address" => "AKdr5d9AMEnsKYxpDcoHdyyjSCKVx3r9Nj",
+                "publicKey" => "020431436cf94f3c6a6ba566fe9e42678db8486590c732ca6c3803a10a86f50b92",
+                "votes" => "316486744580272",
+                "rank" => 1,
+                "isResigned" => false,
+            ], [
+                "username" => "biz_classic",
+                "address" => "AKdr5d9AMEnsKYxpDcoHdyyjSCKVx3r9Nj",
+                "publicKey" => "020431436cf94f3c6a6ba566fe9e42678db8486590c732ca6c3803a10a86f50b92",
+                "votes" => "316486744580272",
+                "rank" => 1,
+                "isResigned" => false,
+            ]]
+        ]);
+    }
+}


### PR DESCRIPTION
## Why? 🤔 

This PR is responsible to create the domain service and factory for delegates collection.

## What changed? 🏗️ 

- Create `DelegatesCollectionFactory`: To build the Delegates Collection Model.
- Create `RetrieveDelegatesService`: To orchestrate the request and creation of the collection delegates.
- Create `CollectionDelegatesSupportBuilder` and `DelegatesListMock`: To help on unit testing.
- Create `DelegatesRequest`: The request structure to the ark api.

## Jira 🧩 
Epic https://blockchain-explorer.atlassian.net/browse/BE-1
Story https://blockchain-explorer.atlassian.net/browse/BE-10

## Feature branch 🚀 
`feature/list-delegates`
